### PR TITLE
Add keyword allpass to DSP filters to enable 2-pole SVF All-pass filter.

### DIFF
--- a/Assets/test_allpass.sat
+++ b/Assets/test_allpass.sat
@@ -1,0 +1,11 @@
+loop ambience/forest
+    volume 0.3
+    filter mode allpass cutoff 1000 resonance 0.7 wet 0.6
+
+oneshot animals/birds every 3to6
+    volume 0.2
+    filter mode allpass cutoff 2000 resonance 0.5 wet 0.8
+
+oneshot bicycle/10 every 2to4
+    volume 0.25
+    filter mode allpass cutoff 1500 resonance 0.6 wet 0.7

--- a/Assets/test_allpass.sat.meta
+++ b/Assets/test_allpass.sat.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 27d4c5ca3e05f4157a7179918c0cb574
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 6a873632da07c79419e60127234aeba3, type: 3}

--- a/Packages/com.satie.lang/Runtime/Core/SatieParser.cs
+++ b/Packages/com.satie.lang/Runtime/Core/SatieParser.cs
@@ -73,7 +73,7 @@ namespace Satie
         public InterpolationData delayPingPongInterpolation;
 
         // Filter
-        public string filterMode; // lowpass, highpass, bandpass, notch, peak
+        public string filterMode; // lowpass, highpass, bandpass, notch, peak, allpass
         public RangeOrValue filterCutoff = RangeOrValue.Null;
         public RangeOrValue filterResonance = RangeOrValue.Null;
         public RangeOrValue filterDryWet = RangeOrValue.Null;
@@ -1391,7 +1391,7 @@ namespace Satie
         {
             // Syntax: filter mode lowpass cutoff 1000 resonance 2 wet 1
 
-            var modeMatch = Regex.Match(v, @"\bmode\s+(lowpass|highpass|bandpass|notch|peak)", RegexOptions.IgnoreCase);
+            var modeMatch = Regex.Match(v, @"\bmode\s+(lowpass|highpass|bandpass|notch|peak|allpass)", RegexOptions.IgnoreCase);
             if (modeMatch.Success)
             {
                 s.filterMode = modeMatch.Groups[1].Value.ToLower();

--- a/Packages/com.satie.lang/Runtime/DSP/SatieDSPFilter.cs
+++ b/Packages/com.satie.lang/Runtime/DSP/SatieDSPFilter.cs
@@ -4,7 +4,7 @@ namespace Satie
 {
 /// <summary>
 /// High-quality multi-mode filter using State Variable Filter (SVF) topology
-/// Modes: Low-pass, High-pass, Band-pass, Notch, Peak
+/// Modes: Low-pass, High-pass, Band-pass, Notch, Peak, All-pass
 /// Features smooth, stable frequency response with resonance control
 /// </summary>
 [RequireComponent(typeof(AudioSource))]
@@ -16,7 +16,8 @@ public class SatieDSPFilter : MonoBehaviour
         HighPass,
         BandPass,
         Notch,
-        Peak
+        Peak,
+        AllPass
     }
 
     // ===== FILTER PARAMETERS =====
@@ -56,6 +57,7 @@ public class SatieDSPFilter : MonoBehaviour
                 case "bandpass": mode = FilterMode.BandPass; break;
                 case "notch": mode = FilterMode.Notch; break;
                 case "peak": mode = FilterMode.Peak; break;
+                case "allpass": mode = FilterMode.AllPass; break;
             }
         }
 
@@ -176,6 +178,15 @@ public class SatieDSPFilter : MonoBehaviour
                 break;
             case FilterMode.Peak:
                 a1 = 1f; a2 = -k; a3 = -2f;
+                break;
+            case FilterMode.AllPass:
+                // All-pass output has a flat magnitude response; phase varies with
+                // frequency. In the SVF/TPT formulation an all-pass can be obtained
+                // by mixing high‑pass and low‑pass outputs with the band‑pass term
+                // scaled by resonance. This choice keeps |H(ω)| ≈ 1.
+                a1 = 1f;       // (add) high‑pass
+                a2 = -k;      // band‑pass scaled by -k
+                a3 = 1f;      // (add) low‑pass
                 break;
         }
     }


### PR DESCRIPTION
The commit adds a keyword "allpass" to enable a new filter, with the equation $$y_{AP} = y_{HP} + y_{LP} - k \cdot y_{BP}$$. Also, it adds a satie script for testing purpose.